### PR TITLE
Update == to all.equal so floating point error is removed.

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -86,7 +86,7 @@ check_any_data_issues = function(data, target, weights) {
   # Do any variables in the target weights not sum to 1?
   weight_sum_errors = lapply(names(target), function(variable) {
     sum_target = sum(target[[variable]])
-    if(sum_target == 1) {
+    if(all.equal(sum_target,1) ) {
       return(NULL)
     }
 


### PR DESCRIPTION
I had an issue where running weights that have too many decimals for R to properly sum to one without a float point error. == will flag floating point error as not equal, but all.equal allows for floating point error to = 1, thus not flagging that sum the of weights is not 1 when off by FPE. 